### PR TITLE
Rename list atts

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The attribute `slice` is a part of the array.
 ```
 [] > list-test
   QQ.hamcrest.assert-that > @
-    reducei.
+    reducedi.
       QQ.collections.list
         * TRUE TRUE FALSE
       TRUE

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The attribute `eq` is TRUE if each element of the array is equal to the correspo
 The attribute `without` is a new array with the i-th element removed.
 
 The attributes `each`, `reduce`, and `map` are respectively similar to forEach, reduce, find, reduce, and map methods of Array object in JavaScript (ECMA, 2011). 
-A few “twin” attributes `reducedi`,  and `mapi`are semantically the same, but with an extra int argument as a counter of a cycle.
+A few “twin” attributes `reducedi`,  and `mappedi`are semantically the same, but with an extra int argument as a counter of a cycle.
 The attribute `slice` is a part of the array.
 
 ```

--- a/src/main/eo/org/eolang/collections/list.eo
+++ b/src/main/eo/org/eolang/collections/list.eo
@@ -81,6 +81,16 @@
         acc
 
   # Reduce from start "a" using the function "f"
+  [a f] > reduced
+    ^.reducedi > @
+      a
+      [a idx item]
+        &.f > @
+          a
+          item
+
+  # @todo #20:30 min. DEPRICATED, please remove after update of objectionary/eo.
+  #  bytes.as-hash in objectionary/eo still use reduce
   [a f] > reduce
     ^.reducedi > @
       a
@@ -162,7 +172,7 @@
 
   # Returns the combined current and passed arrays
   [passed] > concat
-    reduce. > @!
+    reduced. > @!
       list
         passed
       ^

--- a/src/main/eo/org/eolang/collections/list.eo
+++ b/src/main/eo/org/eolang/collections/list.eo
@@ -84,6 +84,13 @@
   # Map without index. Here "f" must be an abstract
   # object with one free attribute, for the element
   # of the array.
+  [f] > mapped
+    ^.mappedi > @
+      [x idx]
+        &.f x > @
+
+  # @todo #20:30 min. DEPRICATED, please remove after update of objectionary/eo.
+  #  some objects in objectionary/eo still use map
   [f] > map
     ^.mappedi > @
       [x idx]

--- a/src/main/eo/org/eolang/collections/list.eo
+++ b/src/main/eo/org/eolang/collections/list.eo
@@ -61,6 +61,7 @@
 
   # @todo #20:30 min. DEPRICATED, please remove after update of objectionary/eo.
   #  string.joined in objectionary/eo still use reducei
+  #  so wnen it will be changed delete that
   [a f] > reducei
     rec-reduce (* a 0) f arr > @
 
@@ -91,6 +92,7 @@
 
   # @todo #20:30 min. DEPRICATED, please remove after update of objectionary/eo.
   #  bytes.as-hash in objectionary/eo still use reduce
+  #  so wnen it will be changed delete that
   [a f] > reduce
     ^.reducedi > @
       a
@@ -122,6 +124,7 @@
 
   # @todo #20:30 min. DEPRICATED, please remove after update of objectionary/eo.
   #  some objects in objectionary/eo still use map
+  #  so wnen it will be changed delete that
   [f] > map
     ^.mappedi > @
       [x idx]

--- a/src/main/eo/org/eolang/collections/list.eo
+++ b/src/main/eo/org/eolang/collections/list.eo
@@ -40,6 +40,27 @@
   # one for the accumulator, the second one
   # for the index and the third one for the element
   # of the array.
+  [a f] > reducedi
+    rec-reduced (* a 0) f arr > @
+
+    [acc-index func carr] > rec-reduced
+      (acc-index.at 0) > acc
+      (acc-index.at 1) > index
+      if. > @
+        (index.lt (carr.length))
+        rec-reduced
+          *
+            func
+              acc
+              index
+              (carr.at index)
+            (index.plus 1)
+          func
+          carr
+        acc
+
+  # @todo #20:30 min. DEPRICATED, please remove after update of objectionary/eo.
+  #  string.joined in objectionary/eo still use reducei
   [a f] > reducei
     rec-reduce (* a 0) f arr > @
 
@@ -61,7 +82,7 @@
 
   # Reduce from start "a" using the function "f"
   [a f] > reduce
-    ^.reducei > @
+    ^.reducedi > @
       a
       [a idx item]
         &.f > @
@@ -74,7 +95,7 @@
   # for the index.
   [f] > mappedi
     list > @
-      ^.reducei
+      ^.reducedi
         *
         [a idx item]
           with. > @
@@ -115,7 +136,7 @@
 
   # Create a new list without the i-th element
   [i] > without
-    ^.reducei > @
+    ^.reducedi > @
       *
       [a idx item]
         if. > @
@@ -129,7 +150,7 @@
       eq.
         arr.length
         x.length
-      ^.reducei
+      ^.reducedi
         TRUE
         [a idx item]
           and. > @

--- a/src/main/eo/org/eolang/collections/list.eo
+++ b/src/main/eo/org/eolang/collections/list.eo
@@ -72,7 +72,7 @@
   # object with two free attributes. The first
   # one for the element of the array, the second one
   # for the index.
-  [f] > mapi
+  [f] > mappedi
     list > @
       ^.reducei
         *
@@ -85,7 +85,7 @@
   # object with one free attribute, for the element
   # of the array.
   [f] > map
-    ^.mapi > @
+    ^.mappedi > @
       [x idx]
         &.f x > @
 

--- a/src/main/eo/org/eolang/collections/map.eo
+++ b/src/main/eo/org/eolang/collections/map.eo
@@ -35,7 +35,7 @@
   # Returns list of all keys in multimap
   [] > keys
     (multimap *).concat-all-arrays m > caa!
-    map. > @
+    mapped. > @
       list
         caa
       [curr]

--- a/src/main/eo/org/eolang/collections/multimap.eo
+++ b/src/main/eo/org/eolang/collections/multimap.eo
@@ -34,7 +34,7 @@
   # Returns list of all keys in multimap
   [] > keys
     ^.concat-all-arrays m > caa!
-    map. > @
+    mapped. > @
       list
         caa
       [curr]

--- a/src/main/eo/org/eolang/collections/multimap.eo
+++ b/src/main/eo/org/eolang/collections/multimap.eo
@@ -45,7 +45,7 @@
     elements-amount > @
 
   [arr] > concat-all-arrays
-    reduce. > @
+    reduced. > @
       list
         arr
       *
@@ -55,7 +55,7 @@
           x
 
   [arr] > pairs-to-hash
-    reduce. > @
+    reduced. > @
       list
         arr
       *
@@ -75,7 +75,7 @@
       mmp
 
   [key arr] > find-in-list
-    reduce. > @
+    reduced. > @
       list
         arr
       *
@@ -99,7 +99,7 @@
       ^.find-in-list key (m.at (num.mod (m.length)))
 
   [key arr] > without-in-list
-    reduce. > @
+    reduced. > @
       list
         arr
       *

--- a/src/test/eo/org/eolang/collections/list-tests.eo
+++ b/src/test/eo/org/eolang/collections/list-tests.eo
@@ -145,7 +145,7 @@
 # reduce without index test
 [] > reduce-without-index-test
   assert-that > @
-    reduce.
+    reduced.
       list
         * 1 2 3 4
       -1
@@ -361,7 +361,7 @@
     7
 
   [] > foo
-    reduce. > res
+    reduced. > res
       list
         * 0
       *

--- a/src/test/eo/org/eolang/collections/list-tests.eo
+++ b/src/test/eo/org/eolang/collections/list-tests.eo
@@ -155,9 +155,9 @@
           x
     $.equal-to -24
 
-[] > mapi-should-works
+[] > mappedi-should-works
   assert-that > @
-    mapi.
+    mappedi.
       list
         * 1 2 3 4
       [x i]
@@ -167,9 +167,9 @@
         * 2 4 6 8
 
 # this test performs mapping of list using the index for it
-[] > mapi-index-can-be-accessed
+[] > mappedi-index-can-be-accessed
   [numbers...] > multipliedByNaturalSequence
-    mapi. > @
+    mappedi. > @
       list numbers
       [current index]
         times. > @

--- a/src/test/eo/org/eolang/collections/list-tests.eo
+++ b/src/test/eo/org/eolang/collections/list-tests.eo
@@ -85,7 +85,7 @@
 [] > reduce-with-index-test
   * 2 2 > src
   assert-that > @
-    reducei.
+    reducedi.
       list
         * 1 1
       0
@@ -96,9 +96,9 @@
             src.at i
     $.equal-to 6
 
-[] > reducei-long-int-array
+[] > reducedi-long-int-array
   assert-that > @
-    reducei.
+    reducedi.
       list
         * 1 2 3 4
       0
@@ -108,9 +108,9 @@
           a
     $.equal-to 10
 
-[] > reducei-bools-array
+[] > reducedi-bools-array
   assert-that > @
-    reducei.
+    reducedi.
       list
         * TRUE TRUE FALSE
       TRUE
@@ -120,13 +120,13 @@
           a
     $.equal-to FALSE
 
-[] > reducei-nested-functions
+[] > reducedi-nested-functions
   [] > a
     10 > @
   [] > b
     500 > @
   assert-that > @
-    reducei.
+    reducedi.
       list
         * a b
       0

--- a/src/test/eo/org/eolang/collections/list-tests.eo
+++ b/src/test/eo/org/eolang/collections/list-tests.eo
@@ -184,30 +184,30 @@
 [] > simple-mapping-int-to-string
   assert-that > @
     length.
-      map.
+      mapped.
         list
           * 1 2 3
         [i]
           (number i).as-string > @
     $.equal-to 3
 
-[] > using-map-as-object
+[] > using-mapped-as-object
   assert-that > @
     (text " ").joined
-      map.
+      mapped.
         list
           * 1 2
         [i]
           (number i).as-string > @
     $.equal-to "1 2"
 
-# if map does mutate lists, then this test would fail
+# if mapped does mutate lists, then this test would fail
 # because of the absence of the as-int attribute
 # that is caused by mutation of the original string list
 # to an int list
-[] > map-does-dot-mutate-array
+[] > mapped-does-dot-mutate-array
   [numbers...] > squares
-    map. > @
+    mapped. > @
       list numbers
       [current]
         pow. > @


### PR DESCRIPTION
@Graur , please review
I renamed reduce, reducei, map, mapi --> reduced, reducedi, mappped, mappedi. Previeous attributes I marked as depricated cause they are used by some assert-that attributes.