### PR TITLE
nested reduce tests added

### DIFF
--- a/src/test/eo/org/eolang/collections/list-tests.eo
+++ b/src/test/eo/org/eolang/collections/list-tests.eo
@@ -439,3 +439,35 @@
   assert-that > @
     list3.at 0
     $.equal-to 1
+
+[] > double-reduce-test
+  reduce. > res!
+    list
+      (* 1)
+    (* (*))
+    [a x]
+      reduce. > @
+        list
+          (* (*))
+        (*)
+        [aaa xxx]
+          (aaa.with xxx) > @
+  assert-that > @
+    ((res.at 0).length)
+    $.equal-to 0
+
+[] > double-reduce-test-2
+  reduce. > res!
+    list
+      (* 1)
+    (* (*))
+    [a x]
+      reduce. > @
+        list
+          a
+        (*)
+        [aaa xxx]
+          (aaa.with xxx) > @
+  assert-that > @
+    ((res.at 0).length)
+    $.equal-to 0


### PR DESCRIPTION
Implemented tests from https://github.com/objectionary/eo-collections/issues/30.
Before we had bugs with nested reduce. And these tests were falling.