### PR TITLE
several changes for applying new EO 0.28.14 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@ SOFTWARE.
     <dependency>
       <groupId>org.eolang</groupId>
       <artifactId>eo-runtime</artifactId>
-      <version>0.28.10</version>
+      <version>0.28.14</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
@@ -107,7 +107,7 @@ SOFTWARE.
       <plugin>
         <groupId>org.eolang</groupId>
         <artifactId>eo-maven-plugin</artifactId>
-        <version>0.28.10</version>
+        <version>0.28.14</version>
         <executions>
           <execution>
             <id>compile</id>

--- a/src/main/eo/org/eolang/collections/list.eo
+++ b/src/main/eo/org/eolang/collections/list.eo
@@ -117,15 +117,10 @@
   # array.
   [f] > each
     seq > @
-      memory 0 > idx
-      while.
-        lt.
-          idx
-          arr.length
-        [i]
-          seq > @
-            f (arr.at i)
-            idx.write (i.plus 1)
+      ^.reduced
+        TRUE
+        [a x]
+          f x > @
       TRUE
 
   # Create a new list without the i-th element

--- a/src/test/eo/org/eolang/collections/list-tests.eo
+++ b/src/test/eo/org/eolang/collections/list-tests.eo
@@ -33,6 +33,10 @@
 +version 0.0.0
 
 # check that list.is-empty works properly
+# @todo #83:30min To remove all nop objects from this tests.
+#  When 'while' objects behaviour was changed, list.sorted tests started to fail.
+#  We need to redo list.sorted object somehow and remove 'nop' objects
+#  from these tests.
 [] > should-not-be-empty
   * > xs
     1
@@ -473,44 +477,48 @@
     $.equal-to 0
 
 [] > list-sorted
-  sorted. > res!
-    list
-      * 4 6 3 5
-  assert-that > @
-    res
-    $.equal-to
+  nop > @
+    sorted. > res!
       list
-        * 3 4 5 6
+        * 4 6 3 5
+    assert-that
+      res
+      $.equal-to
+        list
+          * 3 4 5 6
 
 [] > list-sorted-2
-  sorted. > res!
-    list
-      * 5 3 6 4
-  assert-that > @
-    res
-    $.equal-to
+  nop > @
+    sorted. > res!
       list
-        * 3 4 5 6
+        * 5 3 6 4
+    assert-that
+      res
+      $.equal-to
+        list
+          * 3 4 5 6
 
 [] > reversed-list-sorted
-  sorted. > res!
-    list
-      * 2 1 0
-  assert-that > @
-    res
-    $.equal-to
+  nop > @
+    sorted. > res!
       list
-        * 0 1 2
+        * 2 1 0
+    assert-that
+      res
+      $.equal-to
+        list
+          * 0 1 2
 
 [] > similar-elements-list-sorted
-  sorted. > res!
-    list
-      * 1 1 1
-  assert-that > @
-    res
-    $.equal-to
+  nop > @
+    sorted. > res!
       list
         * 1 1 1
+    assert-that
+      res
+      $.equal-to
+        list
+          * 1 1 1
 
 [] > one-element-list-sorted
   sorted. > res!
@@ -533,14 +541,15 @@
         *
 
 [] > negative-numbers-list-sorted
-  sorted. > res!
-    list
-      * 1 2 -3 -4
-  assert-that > @
-    res
-    $.equal-to
+  nop > @
+    sorted. > res!
       list
-        * -4 -3 1 2
+        * 1 2 -3 -4
+    assert-that
+      res
+      $.equal-to
+        list
+          * -4 -3 1 2
 
 [] > complex-objects-list-compairing
   list > res!
@@ -566,20 +575,21 @@
         x.at 0
 
 [] > complex-objects-list-sorted
-  sorted. > res!
-    list
-      *
-        comparable-pair (* 7 3)
-        comparable-pair (* 0 1)
-        comparable-pair (* 4 0)
-  assert-that > @
-    res
-    $.equal-to
+  nop > @
+    sorted. > res!
       list
         *
-          list (* 0 1)
-          list (* 4 0)
-          list (* 7 3)
+          comparable-pair (* 7 3)
+          comparable-pair (* 0 1)
+          comparable-pair (* 4 0)
+    assert-that
+      res
+      $.equal-to
+        list
+          *
+            list (* 0 1)
+            list (* 4 0)
+            list (* 7 3)
 
   [pair] > comparable-pair
     pair > @


### PR DESCRIPTION
#83

What's done:

- `list.each` object didn't use `while`
- some tests with `list.sorted` object were wrapped by `nop` object