### PR TITLE
fix: maven-compiler-version 3.11.0 -> 3.8.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@ SOFTWARE.
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.11.0</version>
+        <version>3.8.1</version>
         <configuration combine.self="override"/>
       </plugin>
       <plugin>


### PR DESCRIPTION
Revert  maven-compiler-version `3.11.0` -> `3.8.1`

Reason: https://github.com/objectionary/eo-collections/pull/157 failed.