### PR TITLE
Replaced test meta from +junit to +tests,

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@ SOFTWARE.
     <dependency>
       <groupId>org.eolang</groupId>
       <artifactId>eo-runtime</artifactId>
-      <version>0.29.2</version>
+      <version>0.29.4</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
@@ -104,7 +104,7 @@ SOFTWARE.
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.11.0</version>
+        <version>3.8.1</version>
         <configuration combine.self="override"/>
       </plugin>
       <plugin>
@@ -117,7 +117,7 @@ SOFTWARE.
       <plugin>
         <groupId>org.eolang</groupId>
         <artifactId>eo-maven-plugin</artifactId>
-        <version>0.29.2</version>
+        <version>0.29.4</version>
         <executions>
           <execution>
             <id>compile</id>

--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,10 @@
   "extends": [
     "config:base"
   ],
-  "ignoreDeps": ["maven-compiler-plugin"]
+  "packageRules": [
+    {
+      "matchPackageNames": ["maven-compiler-plugin"],
+      "allowedVersions": "3.8.1"
+    }
+  ]
 }

--- a/src/test/eo/org/eolang/collections/bytes-as-array-tests.eo
+++ b/src/test/eo/org/eolang/collections/bytes-as-array-tests.eo
@@ -24,8 +24,8 @@
 +alias org.eolang.collections.list
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo
-+junit
 +package org.eolang.collections
++tests
 +version 0.0.0
 
 [] > bytes-to-array

--- a/src/test/eo/org/eolang/collections/list-tests.eo
+++ b/src/test/eo/org/eolang/collections/list-tests.eo
@@ -28,8 +28,8 @@
 +alias org.eolang.txt.sscanf
 +alias org.eolang.txt.text
 +home https://github.com/objectionary/eo-collections
-+junit
 +package org.eolang.collections
++tests
 +version 0.0.0
 
 # check that list.is-empty works properly

--- a/src/test/eo/org/eolang/collections/map-tests.eo
+++ b/src/test/eo/org/eolang/collections/map-tests.eo
@@ -24,8 +24,8 @@
 +alias org.eolang.collections.map
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-collections
-+junit
 +package org.eolang.collections
++tests
 +version 0.0.0
 
 [] > map-find-do-not-crashed

--- a/src/test/eo/org/eolang/collections/multimap-tests.eo
+++ b/src/test/eo/org/eolang/collections/multimap-tests.eo
@@ -24,8 +24,8 @@
 +alias org.eolang.collections.multimap
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-collections
-+junit
 +package org.eolang.collections
++tests
 +version 0.0.0
 
 [] > rebuild-do-not-crush

--- a/src/test/eo/org/eolang/collections/range-tests.eo
+++ b/src/test/eo/org/eolang/collections/range-tests.eo
@@ -24,8 +24,8 @@
 +alias org.eolang.collections.list
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-collections
-+junit
 +package org.eolang.collections
++tests
 +version 0.0.0
 
 [] > simple-range

--- a/src/test/eo/org/eolang/collections/set-tests.eo
+++ b/src/test/eo/org/eolang/collections/set-tests.eo
@@ -24,8 +24,8 @@
 +alias org.eolang.collections.set
 +alias org.eolang.hamcrest.assert-that
 +home https://github.com/objectionary/eo-collections
-+junit
 +package org.eolang.collections
++tests
 +version 0.0.0
 
 [] > set-works


### PR DESCRIPTION
Closes: #169

- Replaced test meta from +junit to +tests,
- updated EO version to 0.29.4,
- added rule to ignore maven-compiler-plugin version update

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates some dependencies and adds package rules to the `renovate.json` file. It also updates the URLs in some test files and adds aliases. 

### Detailed summary
- Added package rules to `renovate.json` file
- Updated URLs in test files 
- Added aliases to test files

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->