### PR TITLE
#175 Replace `as-hash` with `hash-code-of`

### DIFF
--- a/src/main/eo/org/eolang/collections/hash-code-of.eo
+++ b/src/main/eo/org/eolang/collections/hash-code-of.eo
@@ -36,7 +36,7 @@
       eq.
         h.as-bytes > h-as-bytes!
         01-
-      1232
+      1231
     *
       h-as-bytes.eq 00-
       1237

--- a/src/main/eo/org/eolang/collections/map.eo
+++ b/src/main/eo/org/eolang/collections/map.eo
@@ -20,6 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
++alias org.eolang.collections.hash-code-of
 +alias org.eolang.collections.list
 +alias org.eolang.collections.multimap
 +alias org.eolang.math.number
@@ -88,7 +89,8 @@
   # If no element was found, it returns an empty array
   [key] > found
     multimap * > mmp!
-    number (key.as-hash) > num!
+    number > num!
+      hash-code-of key
     if. > @
       eq.
         m.length

--- a/src/main/eo/org/eolang/collections/map.eo
+++ b/src/main/eo/org/eolang/collections/map.eo
@@ -69,9 +69,6 @@
 
   # Returns the new map with added object
   # Replaces if there was one before
-  # @todo #156:30min. Replace all "as-hash" object usings with "hash-code-of".
-  #  In order to make "eo-runtime" independent of "eo-collections" need to
-  #  replace all "as-hash" objects with new "hash-code-of" object.
   [key value] > with
     multimap * > mmp!
     * key value > new-pair!

--- a/src/main/eo/org/eolang/collections/multimap.eo
+++ b/src/main/eo/org/eolang/collections/multimap.eo
@@ -20,6 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
++alias org.eolang.collections.hash-code-of
 +alias org.eolang.collections.list
 +alias org.eolang.math.number
 +home https://github.com/objectionary/eo-collections
@@ -59,7 +60,9 @@
         arr
       *
       [a x]
-        a.with (x.at 0).as-hash > @
+        a.with > @
+          hash-code-of
+            x.at 0
 
   # Returns the new map with added object
   [key value] > with
@@ -89,7 +92,8 @@
   # Returns an array with the found value
   # If no element was found, it returns an empty array
   [key] > found
-    number (key.as-hash) > num!
+    number > num!
+      hash-code-of key
     if. > @
       eq.
         m.length

--- a/src/test/eo/org/eolang/collections/multimap-tests.eo
+++ b/src/test/eo/org/eolang/collections/multimap-tests.eo
@@ -20,6 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
++alias org.eolang.collections.hash-code-of
 +alias org.eolang.collections.list
 +alias org.eolang.collections.multimap
 +alias org.eolang.hamcrest.assert-that
@@ -181,8 +182,9 @@
   TRUE > a!
   1231 > b!
   assert-that > @
-    a.as-hash
-    $.equal-to (b.as-hash)
+    hash-code-of a
+    $.equal-to
+      hash-code-of b
 
 # @todo #15:30min This test was temporary disabled here.
 #  As we have problems with little size of stack, this test falls


### PR DESCRIPTION
Closes: #175

<!-- start pr-codex -->

---

## PR-Codex overview
This PR replaces all `as-hash` objects with a new `hash-code-of` object in order to make `eo-runtime` independent of `eo-collections`.

### Detailed summary
- Replaces all `as-hash` objects with a new `hash-code-of` object in `multimap.eo` and `map.eo`.
- Adds `hash-code-of` alias to `multimap-tests.eo` and `hash-code-of.eo`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->