### PR TITLE
#182 Introduced `range-of-ints` object

### DIFF
--- a/src/main/eo/org/eolang/collections/list.eo
+++ b/src/main/eo/org/eolang/collections/list.eo
@@ -256,6 +256,12 @@
         a.write b
         b.write temp
 
+  # @todo #182:30min Object "rec-filtered" inside "filteredi" can be simplified
+  #  without using object "seq". To achieve that object "rec-filtered" should
+  #  check if "index" is equals to length of "carr" at the beginning. If it's
+  #  TRUE - "new-list" should be returned. If it's FALSE - new recursive
+  #  iteration should be started.
+  #
   # Filter list with index with the function "f".
   # Here "f" must be an abstract
   # object with two attributes. The first

--- a/src/main/eo/org/eolang/collections/list.eo
+++ b/src/main/eo/org/eolang/collections/list.eo
@@ -260,7 +260,7 @@
   #  without using object "seq". To achieve that object "rec-filtered" should
   #  check if "index" is equals to length of "carr" at the beginning. If it's
   #  TRUE - "new-list" should be returned. If it's FALSE - new recursive
-  #  iteration should be started.
+  #  iteration should be started. Use "list.reducedi" as an example.
   #
   # Filter list with index with the function "f".
   # Here "f" must be an abstract

--- a/src/main/eo/org/eolang/collections/range-of-ints.eo
+++ b/src/main/eo/org/eolang/collections/range-of-ints.eo
@@ -1,0 +1,45 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2022 Yegor Bugayenko
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++alias org.eolang.collections.range
++alias org.eolang.math.number
++home https://github.com/objectionary/eo-collections
++package org.eolang.collections
++rt jvm org.eolang:eo-collections:0.0.0
++version 0.0.0
+
+# Range of integers from "start" to "end" (soft border) with step = 1
+[start end] > range-of-ints
+  if. > @
+    and.
+      is-int.
+        number start
+      is-int.
+        number end
+    range
+      []
+        [num] > build
+          num > @
+          build (@.plus 1) > next
+        build start > @
+      end
+    error "some of the arguments are not integers"

--- a/src/test/eo/org/eolang/collections/range-of-ints-tests.eo
+++ b/src/test/eo/org/eolang/collections/range-of-ints-tests.eo
@@ -1,0 +1,72 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2021-2022 Yegor Bugayenko
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++alias org.eolang.collections.list
++alias org.eolang.collections.range-of-ints
++alias org.eolang.hamcrest.assert-that
++home https://github.com/objectionary/eo-collections
++package org.eolang.collections
++tests
++version 0.0.0
+
+[] > simple-range-of-ints
+  assert-that > @
+    list
+      range-of-ints 1 10
+    $.equal-to
+      list
+        * 1 2 3 4 5 6 7 8 9
+
+[] > range-of-negative-ints
+  assert-that > @
+    list
+      range-of-ints -5 0
+    $.equal-to
+      list
+        * -5 -4 -3 -2 -1
+
+[] > range-of-ints-with-not-int-start
+  try > @
+    range-of-ints 1.2 3
+    [ex]
+      assert-that > @
+        ex
+        $.equal-to "some of the arguments are not integers"
+    nop
+
+[] > range-of-ints-with-not-int-end
+  try > @
+    range-of-ints 1 2.5
+    [ex]
+      assert-that > @
+        ex
+        $.equal-to "some of the arguments are not integers"
+    nop
+
+[] > range-of-not-ints
+  try > @
+    range-of-ints 1.5 5.2
+    [ex]
+      assert-that > @
+        ex
+        $.equal-to "some of the arguments are not integers"
+    nop

--- a/src/test/eo/org/eolang/collections/range-of-ints-tests.eo
+++ b/src/test/eo/org/eolang/collections/range-of-ints-tests.eo
@@ -36,6 +36,18 @@
       list
         * 1 2 3 4 5 6 7 8 9
 
+[] > empty-range-of-ints
+  assert-that > @
+    length.
+      range-of-ints 10 10
+    $.equal-to 0
+
+[] > range-of-descending-ints
+  assert-that > @
+    length.
+      range-of-ints 10 1
+    $.equal-to 0
+
 [] > range-of-negative-ints
   assert-that > @
     list


### PR DESCRIPTION
Closes: #182

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a range-of-ints object with a test suite and a todo comment for simplifying the object. 

### Detailed summary
- Added `range-of-ints` object with start and end integer arguments
- Added a test suite for `range-of-ints` object
- Added a todo comment for simplifying the `rec-filtered` object inside `filteredi`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->