### PR TITLE
#184 Improved `list.filteredi`

### DIFF
--- a/src/main/eo/org/eolang/collections/list.eo
+++ b/src/main/eo/org/eolang/collections/list.eo
@@ -275,11 +275,11 @@
         list *
 
     [index-carr func new-list] > rec-filtered
-      index-carr.at 0 > index
-      index-carr.at 1 > carr
-      carr.at index > item
       if. > @
-        index.eq carr.length
+        eq.
+          index-carr.at 0 > index
+          length.
+            index-carr.at 1 > carr
         new-list
         rec-filtered
           *
@@ -288,7 +288,7 @@
           func
           if.
             func
-              item
+              carr.at index > item
               index
             new-list.with item
             new-list

--- a/src/main/eo/org/eolang/collections/list.eo
+++ b/src/main/eo/org/eolang/collections/list.eo
@@ -256,12 +256,6 @@
         a.write b
         b.write temp
 
-  # @todo #182:30min Object "rec-filtered" inside "filteredi" can be simplified
-  #  without using object "seq". To achieve that object "rec-filtered" should
-  #  check if "index" is equals to length of "carr" at the beginning. If it's
-  #  TRUE - "new-list" should be returned. If it's FALSE - new recursive
-  #  iteration should be started. Use "list.reducedi" as an example.
-  #
   # Filter list with index with the function "f".
   # Here "f" must be an abstract
   # object with two attributes. The first
@@ -284,23 +278,20 @@
       index-carr.at 0 > index
       index-carr.at 1 > carr
       carr.at index > item
-      seq > @
-        func > acc!
-          item
-          index
-        if. > filt-list
-          eq.
-            acc
-            TRUE
-          new-list.with item
-          new-list
-        if.
-          (index.plus 1).eq (carr.length)
-          filt-list
-          rec-filtered
-            * (index.plus 1) carr
+      if. > @
+        index.eq carr.length
+        new-list
+        rec-filtered
+          *
+            index.plus 1
+            carr
+          func
+          if.
             func
-            filt-list
+              item
+              index
+            new-list.with item
+            new-list
 
   # Filter list without index with the function "f".
   # Here "f" must be an abstract object


### PR DESCRIPTION
Closes: #184 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR simplifies the `rec-filtered` object inside `filteredi` in `list.eo`. 

### Detailed summary
- `rec-filtered` object now checks if `index` is equal to the length of `carr` at the beginning
- If `index` is `TRUE`, `new-list` is returned. Otherwise, a new recursive iteration is started
- `list.reducedi` is used as an example
- The changes simplify the `rec-filtered` object and remove the need for the `seq` object

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->