### PR TITLE
EO was up to 0.29.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@ SOFTWARE.
     <dependency>
       <groupId>org.eolang</groupId>
       <artifactId>eo-runtime</artifactId>
-      <version>0.29.6</version>
+      <version>0.29.4</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
@@ -117,7 +117,7 @@ SOFTWARE.
       <plugin>
         <groupId>org.eolang</groupId>
         <artifactId>eo-maven-plugin</artifactId>
-        <version>0.29.6</version>
+        <version>0.29.4</version>
         <executions>
           <execution>
             <id>compile</id>

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@ SOFTWARE.
     <dependency>
       <groupId>org.eolang</groupId>
       <artifactId>eo-runtime</artifactId>
-      <version>0.29.4</version>
+      <version>0.29.6</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@ SOFTWARE.
       <plugin>
         <groupId>org.eolang</groupId>
         <artifactId>eo-maven-plugin</artifactId>
-        <version>0.29.4</version>
+        <version>0.29.6</version>
         <executions>
           <execution>
             <id>compile</id>

--- a/src/main/eo/org/eolang/collections/hash-code-of.eo
+++ b/src/main/eo/org/eolang/collections/hash-code-of.eo
@@ -48,30 +48,29 @@
           h-as-bytes.right 32
     *
       TRUE
-      []
-        [acc index bytes zero-as-bytes] > rec-hash-code
-          if. > @
-            index.eq bytes.length
-            acc
-            rec-hash-code
-              plus.
-                times.
-                  31
-                  acc
-                as-int.
-                  right.
-                    zero-as-bytes.and
-                      bytes.at index
-                    54
-              index.plus 1
-              bytes
-              zero-as-bytes
-
-        0.as-bytes > zero-as-bytes!
-
-        rec-hash-code > @
-          1
-          0
-          bytes-as-array
-            h-as-bytes
-          zero-as-bytes
+      hc
+    [] > hc
+      [acc index bytes zero-as-bytes] > rec-hash-code
+        if. > @
+          index.eq bytes.length
+          acc
+          rec-hash-code
+            plus.
+              times.
+                31
+                acc
+              as-int.
+                right.
+                  zero-as-bytes.and
+                    bytes.at index
+                  54
+            index.plus 1
+            bytes
+            zero-as-byte
+      0.as-bytes > zero-as-bytes
+      rec-hash-code > @
+        1
+        0
+        bytes-as-array
+          h-as-bytes
+        zero-as-bytes

--- a/src/main/eo/org/eolang/collections/hash-code-of.eo
+++ b/src/main/eo/org/eolang/collections/hash-code-of.eo
@@ -50,7 +50,7 @@
       TRUE
       hc
     [] > hc
-      [acc index bytes zero-as-bytes] > rec-hash-code
+      [acc index bytes] > rec-hash-code
         if. > @
           index.eq bytes.length
           acc
@@ -61,16 +61,14 @@
                 acc
               as-int.
                 right.
-                  zero-as-bytes.and
+                  0.as-bytes.and
                     bytes.at index
                   54
             index.plus 1
             bytes
-            zero-as-byte
-      0.as-bytes > zero-as-bytes
+            0.as-bytes
       rec-hash-code > @
         1
         0
         bytes-as-array
           h-as-bytes
-        zero-as-bytes

--- a/src/main/eo/org/eolang/collections/hash-code-of.eo
+++ b/src/main/eo/org/eolang/collections/hash-code-of.eo
@@ -49,26 +49,25 @@
     *
       TRUE
       hc
-    [] > hc
-      [acc index bytes] > rec-hash-code
-        if. > @
-          index.eq bytes.length
-          acc
-          rec-hash-code
-            plus.
-              times.
-                31
-                acc
-              as-int.
-                right.
-                  0.as-bytes.and
-                    bytes.at index
-                  54
-            index.plus 1
-            bytes
-            0.as-bytes
-      rec-hash-code > @
-        1
-        0
-        bytes-as-array
-          h-as-bytes
+  [] > hc
+    [acc index bytes] > rec-hash-code
+      if. > @
+        index.eq bytes.length
+        acc
+        rec-hash-code
+          plus.
+            times.
+              31
+              acc
+            as-int.
+              right.
+                0.as-bytes.and
+                  bytes.at index
+                54
+          index.plus 1
+          bytes
+    rec-hash-code > @
+      1
+      0
+      bytes-as-array
+        h-as-bytes

--- a/src/main/eo/org/eolang/collections/map.eo
+++ b/src/main/eo/org/eolang/collections/map.eo
@@ -65,7 +65,10 @@
 
   # Returns amount of elements in multimap
   [] > size
-    elements-amount > @
+    if. > @
+      TRUE
+      elements-amount
+      elements-amount
 
   # Returns the new map with added object
   # Replaces if there was one before

--- a/src/main/eo/org/eolang/collections/multimap.eo
+++ b/src/main/eo/org/eolang/collections/multimap.eo
@@ -42,7 +42,10 @@
 
   # Returns amount of elements in multimap
   [] > size
-    elements-amount > @
+    if. > @
+      TRUE
+      elements-amount
+      elements-amount
 
   [arr] > concat-all-arrays
     reduced. > @

--- a/src/main/eo/org/eolang/collections/range-of-ints.eo
+++ b/src/main/eo/org/eolang/collections/range-of-ints.eo
@@ -35,11 +35,10 @@
         number start
       is-int.
         number end
-    range
-      []
-        [num] > build
-          num > @
-          build (@.plus 1) > next
-        build start > @
-      end
+    range run end
+    [] > run
+      [num] > build
+        num > @
+        build (@.plus 1) > next
+      build start > @
     error "some of the arguments are not integers"

--- a/src/main/eo/org/eolang/collections/range-of-ints.eo
+++ b/src/main/eo/org/eolang/collections/range-of-ints.eo
@@ -35,10 +35,10 @@
         number start
       is-int.
         number end
-    range run end
-    [] > run
-      [num] > build
-        num > @
-        build (@.plus 1) > next
-      build start > @
+    range st end
     error "some of the arguments are not integers"
+  [] > st
+    [num] > build
+      num > @
+      build (@.plus 1) > next
+    build start > @

--- a/src/main/eo/org/eolang/collections/range.eo
+++ b/src/main/eo/org/eolang/collections/range.eo
@@ -43,22 +43,20 @@
 # "1.plus 1" and also has object next. Since these objects are ints - they have
 # object "lt" by default
 [start end] > range
-  [] > @
-    [acc current last] > append
-      if. > @
-        current.lt last
-        []
-          append > @
-            acc.with current
-            current.next
-            last
-        acc
-
+  [acc current last] > append
     if. > @
-      start.lt end
+      current.lt last
       append
-        * start
-        start.next
-        end
-      *
+        acc.with current
+        current.next
+        last
+      acc
+
+  if. > @
+    start.lt end
+    append
+      * start
+      start.next
+      end
+    *
 

--- a/src/main/eo/org/eolang/collections/set.eo
+++ b/src/main/eo/org/eolang/collections/set.eo
@@ -35,30 +35,29 @@
   if. > @!
     lst.is-empty
     lst
-    []
-      reduced. > @
-        at.
-          reducedi.
-            lst
-            *
-              map *
-              list *
-            [acc item index]
-              acc.at 0 > mp!
-              if. > @
-                not.
-                  eq.
-                    length.
-                      mp.found item
-                    0
-                acc
-                *
-                  mp.with item 1
-                  (acc.at 1).with index
-          1
-        list *
-        [acc index]
-          acc.with (lst.at index) > @
+    reduced.
+      at.
+        reducedi.
+          lst
+          *
+            map *
+            list *
+          [acc item index]
+            acc.at 0 > mp!
+            if. > @
+              not.
+                eq.
+                  length.
+                    mp.found item
+                  0
+              acc
+              *
+                mp.with item 1
+                (acc.at 1).with index
+        1
+      list *
+      [acc index]
+        acc.with (lst.at index) > @
 
   [x] > with
     set > @

--- a/src/test/eo/org/eolang/collections/list-tests.eo
+++ b/src/test/eo/org/eolang/collections/list-tests.eo
@@ -169,14 +169,10 @@
     $.equal-to FALSE
 
 [] > reducedi-nested-functions
-  [] > a
-    10 > @
-  [] > b
-    500 > @
   assert-that > @
     reducedi.
       list
-        * a b
+        * 10 500
       0
       [acc x i]
         check x > @

--- a/src/test/eo/org/eolang/collections/range-tests.eo
+++ b/src/test/eo/org/eolang/collections/range-tests.eo
@@ -30,12 +30,13 @@
 
 [] > simple-range
   range > rng!
-    []
-      [i] > build
-        i > @!
-        build (@.plus 1) > next
-      build 1 > @
+    start
     10
+  [] > start
+    [i] > build
+      i > @!
+      build (@.plus 1) > next
+    build 1 > @
   assert-that > @
     list rng
     $.equal-to
@@ -44,12 +45,13 @@
 
 [] > range-with-floats
   range > rng!
-    []
-      [i] > x
-        i > @!
-        x (@.plus 0.5) > next
-      x 1.0 > @
+    start
     5.0
+  [] > start
+    [i] > x
+      i > @!
+      x (@.plus 0.5) > next
+    x 1.0 > @
   assert-that > @
     list rng
     $.equal-to
@@ -58,12 +60,13 @@
 
 [] > range-with-out-of-bounds
   range > rng!
-    []
-      [num] > b
-        num > @!
-        b (@.plus 5) > next
-      b 1 > @
+    start
     10
+  [] > start
+    [num] > b
+      num > @!
+      b (@.plus 5) > next
+    b 1 > @
   assert-that > @
     list rng
     $.equal-to
@@ -99,12 +102,13 @@
 
 [] > range-with-wrong-items-is-an-empty-array
   range > rng!
-    []
-      [num] > y
-        num > @
-        [] > next
-      y 10 > @
+    start
     1
+  [] > start
+    [num] > y
+      num > @
+      [] > next
+    y 10 > @
   assert-that > @
     (list rng).is-empty
     $.equal-to TRUE


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of this PR:
This PR focuses on making changes to several EO files in the codebase related to collections, such as list, multimap, map, range, set, and hash-code-of.

### Detailed summary:
- In `list-tests.eo`, the values in the list are changed from `a` and `b` to `10` and `500`.
- In `multimap.eo` and `map.eo`, the `elements-amount` method is replaced with an `if` statement.
- In `range-of-ints.eo`, the `range` object is modified to accept `start` and `end` arguments instead of an empty list.
- In `range.eo`, the `range` object is modified to accept `start` and `end` arguments instead of an empty list.
- In `set.eo`, the `lst.is-empty` method is replaced with `reduced.` and `at.`.
- In `hash-code-of.eo`, the `rec-hash-code` method is modified to use the `hc` object instead of an empty list.
- In `range-tests.eo`, the `simple-range`, `range-with-floats`, `range-with-out-of-bounds`, and `range-with-wrong-items-is-an-empty-array` methods are modified to accept `start` arguments instead of an empty list.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->