### PR TITLE
feat(#201): remove empty lines and sparse decorations

### DIFF
--- a/src/main/eo/org/eolang/collections/hash-code-of.eo
+++ b/src/main/eo/org/eolang/collections/hash-code-of.eo
@@ -66,9 +66,7 @@
               index.plus 1
               bytes
               zero-as-bytes
-
         0.as-bytes > zero-as-bytes!
-
         rec-hash-code > @
           1
           0

--- a/src/main/eo/org/eolang/collections/list.eo
+++ b/src/main/eo/org/eolang/collections/list.eo
@@ -347,7 +347,6 @@
   [i] > head
     i > index!
     0 > zero!
-
     switch > @
       *
         index.eq zero

--- a/src/main/eo/org/eolang/collections/map.eo
+++ b/src/main/eo/org/eolang/collections/map.eo
@@ -35,6 +35,7 @@
 #  or simplify them. Also we should remove rebuild method in multimap file
 [m] > map
   memory 0 > elements-amount
+  elements-amount > size
 
   # Returns list of all keys in multimap
   [] > keys
@@ -62,10 +63,6 @@
           eq.
             x
             key
-
-  # Returns amount of elements in multimap
-  [] > size
-    elements-amount > @
 
   # Returns the new map with added object
   # Replaces if there was one before

--- a/src/main/eo/org/eolang/collections/multimap.eo
+++ b/src/main/eo/org/eolang/collections/multimap.eo
@@ -30,6 +30,7 @@
 
 [m] > multimap
   memory 0 > elements-amount
+  elements-amount > size
 
   # Returns list of all keys in multimap
   [] > keys
@@ -39,10 +40,6 @@
         caa
       [curr]
         curr.at 0 > @
-
-  # Returns amount of elements in multimap
-  [] > size
-    elements-amount > @
 
   [arr] > concat-all-arrays
     reduced. > @

--- a/src/main/eo/org/eolang/collections/range.eo
+++ b/src/main/eo/org/eolang/collections/range.eo
@@ -47,7 +47,7 @@
     [acc current last] > append
       if. > @
         current.lt last
-        append > @
+        append
           acc.with current
           current.next
           last

--- a/src/main/eo/org/eolang/collections/range.eo
+++ b/src/main/eo/org/eolang/collections/range.eo
@@ -47,13 +47,11 @@
     [acc current last] > append
       if. > @
         current.lt last
-        []
-          append > @
-            acc.with current
-            current.next
-            last
+        append > @
+          acc.with current
+          current.next
+          last
         acc
-
     if. > @
       start.lt end
       append
@@ -61,4 +59,3 @@
         start.next
         end
       *
-

--- a/src/main/eo/org/eolang/collections/set.eo
+++ b/src/main/eo/org/eolang/collections/set.eo
@@ -35,30 +35,29 @@
   if. > @!
     lst.is-empty
     lst
-    []
-      reduced. > @
-        at.
-          reducedi.
-            lst
-            *
-              map *
-              list *
-            [acc item index]
-              acc.at 0 > mp!
-              if. > @
-                not.
-                  eq.
-                    length.
-                      mp.found item
-                    0
-                acc
-                *
-                  mp.with item 1
-                  (acc.at 1).with index
-          1
-        list *
-        [acc index]
-          acc.with (lst.at index) > @
+    reduced. > @
+      at.
+        reducedi.
+          lst
+          *
+            map *
+            list *
+          [acc item index]
+            acc.at 0 > mp!
+            if. > @
+              not.
+                eq.
+                  length.
+                    mp.found item
+                  0
+              acc
+              *
+                mp.with item 1
+                (acc.at 1).with index
+        1
+      list *
+      [acc index]
+        acc.with (lst.at index) > @
 
   [x] > with
     set > @

--- a/src/main/eo/org/eolang/collections/set.eo
+++ b/src/main/eo/org/eolang/collections/set.eo
@@ -35,7 +35,7 @@
   if. > @!
     lst.is-empty
     lst
-    reduced. > @
+    reduced.
       at.
         reducedi.
           lst

--- a/src/test/eo/org/eolang/collections/range-tests.eo
+++ b/src/test/eo/org/eolang/collections/range-tests.eo
@@ -81,12 +81,10 @@
       *
         (@.at 0).plus 1
         (@.at 1).plus 1
-
   range > rng!
     comparable-pair
       * 1 2
     * 5
-
   assert-that > @
     list rng
     $.equal-to


### PR DESCRIPTION
Ref: #201

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
The focus of this PR is to make changes to various EO files related to collections such as list, range, multimap, map, and set.

### Detailed summary:
- In `list.eo`, the `index.eq zero` condition has been modified.
- In `hash-code-of.eo`, the `0.as-bytes` has been changed to `zero-as-bytes`.
- In `range-tests.eo`, some lines of code related to the `range` object have been modified.
- In `range.eo`, some lines of code related to the `if.` condition and `append` function have been modified.
- In `multimap.eo` and `map.eo`, the `elements-amount` has been changed to `size`.
- In `multimap.eo`, the `size` function and `concat-all-arrays` function have been removed.
- In `map.eo`, the `size` function has been removed and the `with` function has been modified.
- In `set.eo`, some lines of code related to the `reduced.` function and `at.` function have been modified.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->