### PR TITLE
Add more tests for `hash-code-of` object

### DIFF
--- a/src/test/eo/org/eolang/collections/hash-code-of-tests.eo
+++ b/src/test/eo/org/eolang/collections/hash-code-of-tests.eo
@@ -31,7 +31,7 @@
 # @todo #156:30min Add more tests for hash-code-of object.
 #  It would be interesting to test floating numbers and, maybe, big numbers
 #  (or some corner cases)
-[] > hash-code-bools-is-integer
+[] > hash-code-of-bools-is-integer
   assert-that > @
     and.
       is-int.
@@ -42,30 +42,79 @@
           hash-code-of FALSE
     $.equal-to TRUE
 
-[] > hash-of-int-is-int
+[] > hash-code-of-int-is-int
   assert-that > @
     is-int.
       number
         hash-code-of 42
     $.equal-to TRUE
 
-[] > hash-codes-of-the-same-numbers-are-equal
+[] > hash-codes-of-the-same-int-are-equal
   42 > forty-two!
   assert-that > @
     hash-code-of forty-two
     $.equal-to
       hash-code-of forty-two
 
-[] > hash-code-of-the-same-strings-are-equal
+[] > hash-codes-of-different-int-are-not-equal-1
+  assert-that > @
+    hash-code-of 42
+    $.not
+      $.equal-to
+        hash-code-of 24
+
+[] > hash-codes-of-different-int-are-not-equal-2
+  assert-that > @
+    hash-code-of 42
+    $.not
+      $.equal-to
+        hash-code-of -42
+
+[] > hash-code-of-string-is-int
+  assert-that > @
+    is-int.
+      number
+        hash-code-of "hello"
+    $.equal-to TRUE
+
+[] > hash-codes-of-the-same-strings-are-equal
   "hello" > str!
   assert-that > @
     hash-code-of str
     $.equal-to
       hash-code-of str
 
-[] > hash-code-of-different-numbers-are-different
-  assert-that > @
-    hash-code-of 42
+# @todo #156:30min Enable this test after fixing issue #205
+#  Don't forget to rename this test
+[] > hash-codes-of-different-strings-are-not-equal-broken
+  assert-that > res
+    hash-code-of "hello!"
     $.not
       $.equal-to
-        hash-code-of 24
+        hash-code-of "help!!"
+  nop > @
+
+[] > hash-codes-of-different-strings-are-not-equal
+  assert-that > @
+    hash-code-of "hello"
+    $.not
+      $.equal-to
+        hash-code-of "bye!!!"
+
+[] > hash-code-of-abstract-object-is-int
+  [x] > obj
+    x > @
+  assert-that > @
+    is-int.
+      number
+        hash-code-of (obj 42)
+    $.equal-to TRUE
+
+[] > hash-codes-of-the-same-abstract-objects-are-equal
+  [x] > obj
+    x > @
+  obj 42 > forty-two-obj!
+  assert-that > @
+    hash-code-of forty-two-obj
+    $.equal-to
+      hash-code-of forty-two-obj

--- a/src/test/eo/org/eolang/collections/hash-code-of-tests.eo
+++ b/src/test/eo/org/eolang/collections/hash-code-of-tests.eo
@@ -46,28 +46,28 @@
         hash-code-of 42
     $.equal-to TRUE
 
-[] > hash-codes-of-the-same-int-are-equal-1
+[] > hash-codes-of-the-same-big-ints-are-equal
   123456789012345678 > big-int!
   assert-that > @
     hash-code-of big-int
     $.equal-to
       hash-code-of big-int
 
-[] > hash-codes-of-the-same-int-are-equal-2
+[] > hash-codes-of-the-same-ints-are-equal
   42 > forty-two!
   assert-that > @
     hash-code-of forty-two
     $.equal-to
       hash-code-of forty-two
 
-[] > hash-codes-of-different-int-are-not-equal-1
+[] > hash-codes-of-different-ints-are-not-equal
   assert-that > @
     hash-code-of 42
     $.not
       $.equal-to
         hash-code-of 24
 
-[] > hash-codes-of-different-int-are-not-equal-2
+[] > hash-codes-of-different-sign-ints-are-not-equal
   assert-that > @
     hash-code-of 42
     $.not
@@ -141,28 +141,28 @@
         hash-code-of 42.42
     $.equal-to TRUE
 
-[] > hash-codes-of-the-same-floats-are-equal-1
+[] > hash-codes-of-the-same-floats-are-equal
   0.911 > emergency!
   assert-that > @
     hash-code-of emergency
     $.equal-to
       hash-code-of emergency
 
-[] > hash-codes-of-the-same-floats-are-equal-2
+[] > hash-codes-of-the-same-big-floats-are-equal
   42.42e42 > big-float!
   assert-that > @
     hash-code-of big-float
     $.equal-to
       hash-code-of big-float
 
-[] > hash-codes-of-different-floats-are-not-equal-1
+[] > hash-codes-of-different-floats-are-not-equal
   assert-that > @
     hash-code-of 3.14
     $.not
       $.equal-to
         hash-code-of 2.72
 
-[] > hash-codes-of-different-floats-are-not-equal-2
+[] > hash-codes-of-different-sign-floats-are-not-equal
   assert-that > @
     hash-code-of 3.22
     $.not

--- a/src/test/eo/org/eolang/collections/hash-code-of-tests.eo
+++ b/src/test/eo/org/eolang/collections/hash-code-of-tests.eo
@@ -89,7 +89,9 @@
       hash-code-of str
 
 # @todo #156:30min Enable this test after fixing issue #205
-#  Don't forget to rename this test
+#  Now all strings of the same length has same hash-code.
+#  This behavior is incorrect and need to be fixed.
+#  Don't forget to rename this test.
 [] > hash-codes-of-different-strings-are-not-equal-broken
   assert-that > res
     hash-code-of "hello!"
@@ -140,7 +142,7 @@
     $.equal-to TRUE
 
 [] > hash-codes-of-the-same-floats-are-equal-1
-  9.11 > emergency!
+  0.911 > emergency!
   assert-that > @
     hash-code-of emergency
     $.equal-to

--- a/src/test/eo/org/eolang/collections/hash-code-of-tests.eo
+++ b/src/test/eo/org/eolang/collections/hash-code-of-tests.eo
@@ -125,3 +125,47 @@
     hash-code-of forty-two-obj
     $.equal-to
       hash-code-of forty-two-obj
+
+[] > hash-codes-of-different-abstract-objects-are-not-equal
+  [x] > obj
+    x > @
+  assert-that > @
+    hash-code-of (obj 42)
+    $.not
+      $.equal-to
+        hash-code-of (obj "42")
+
+[] > hash-code-of-float-is-int
+  assert-that > @
+    is-int.
+      number
+        hash-code-of 42.42
+    $.equal-to TRUE
+
+[] > hash-codes-of-the-same-floats-are-equal-1
+  9.11 > emergency!
+  assert-that > @
+    hash-code-of emergency
+    $.equal-to
+      hash-code-of emergency
+
+[] > hash-codes-of-the-same-floats-are-equal-2
+  42.42e42 > big-float!
+  assert-that > @
+    hash-code-of big-float
+    $.equal-to
+      hash-code-of big-float
+
+[] > hash-codes-of-different-floats-are-not-equal-1
+  assert-that > @
+    hash-code-of 3.14
+    $.not
+      $.equal-to
+        hash-code-of 2.72
+
+[] > hash-codes-of-different-floats-are-not-equal-2
+  assert-that > @
+    hash-code-of 3.22
+    $.not
+      $.equal-to
+        hash-code-of -3.22

--- a/src/test/eo/org/eolang/collections/hash-code-of-tests.eo
+++ b/src/test/eo/org/eolang/collections/hash-code-of-tests.eo
@@ -49,7 +49,14 @@
         hash-code-of 42
     $.equal-to TRUE
 
-[] > hash-codes-of-the-same-int-are-equal
+[] > hash-codes-of-the-same-int-are-equal-1
+  123456789012345678 > big-int!
+  assert-that > @
+    hash-code-of big-int
+    $.equal-to
+      hash-code-of big-int
+
+[] > hash-codes-of-the-same-int-are-equal-2
   42 > forty-two!
   assert-that > @
     hash-code-of forty-two

--- a/src/test/eo/org/eolang/collections/hash-code-of-tests.eo
+++ b/src/test/eo/org/eolang/collections/hash-code-of-tests.eo
@@ -28,9 +28,6 @@
 +package org.eolang.collections
 +version 0.0.0
 
-# @todo #156:30min Add more tests for hash-code-of object.
-#  It would be interesting to test floating numbers and, maybe, big numbers
-#  (or some corner cases)
 [] > hash-code-of-bools-is-integer
   assert-that > @
     and.


### PR DESCRIPTION
Closes #176

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding more tests for the `hash-code-of` object. The tests cover various scenarios including booleans, integers, big integers, strings, abstract objects, and floats.

### Detailed summary
- Renamed test `hash-code-bools-is-integer` to `hash-code-of-bools-is-integer`
- Added tests for hashing booleans and integers
- Added tests for hashing big integers
- Added tests for hashing different integers
- Added tests for hashing different sign integers
- Added tests for hashing strings
- Added tests for hashing different strings (disabled due to an issue)
- Added tests for hashing abstract objects
- Added tests for hashing different abstract objects
- Added tests for hashing floats
- Added tests for hashing different floats
- Added tests for hashing different sign floats

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->